### PR TITLE
View character mounts on details page

### DIFF
--- a/src/components/CharacterDetails.js
+++ b/src/components/CharacterDetails.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import '../styles/CharacterDetails.scss';
 import CharacterBasics from './CharacterBasics';
@@ -9,6 +9,12 @@ import Welcome from './Welcome';
 function CharacterDetails() {
 	const currentCharKey = useSelector((state) => state.session.currentChar);
 	const currentChar = useSelector((state) => state.characters[currentCharKey]);
+	const [ activeDetail, setActiveDetail ] = useState('gear');
+
+	const activeDetailMapping = {
+		gear: <CharacterGear />,
+		mounts: <CharacterMounts />
+	};
 
 	// If a character has been fetched display its data
 	// If an error occurred fetching a character, display the alert
@@ -17,8 +23,21 @@ function CharacterDetails() {
 		<div className='details-container'>
 			<div className='details-data'>
 				<CharacterBasics />
-				<CharacterGear />
-				<CharacterMounts />
+				<nav className='detail-select-nav'>
+					<button
+						onClick={() => setActiveDetail('gear')}
+						className={activeDetail === 'gear' ? 'detail-select active' : 'detail-select'}
+					>
+						Display Gear
+					</button>
+					<button
+						onClick={() => setActiveDetail('mounts')}
+						className={activeDetail === 'mounts' ? 'detail-select active' : 'detail-select'}
+					>
+						Display Mounts
+					</button>
+				</nav>
+				{activeDetailMapping[activeDetail]}
 			</div>
 			<img className='character-model' src={currentChar.assets.main} alt={`${currentChar.name} profile`} />
 		</div>

--- a/src/components/CharacterDetails.js
+++ b/src/components/CharacterDetails.js
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import '../styles/CharacterDetails.scss';
 import CharacterBasics from './CharacterBasics';
 import CharacterGear from './CharacterGear';
+import CharacterMounts from './CharacterMounts';
 import Welcome from './Welcome';
 
 function CharacterDetails() {
@@ -17,6 +18,7 @@ function CharacterDetails() {
 			<div className='details-data'>
 				<CharacterBasics />
 				<CharacterGear />
+				<CharacterMounts />
 			</div>
 			<img className='character-model' src={currentChar.assets.main} alt={`${currentChar.name} profile`} />
 		</div>

--- a/src/components/CharacterMounts.js
+++ b/src/components/CharacterMounts.js
@@ -25,9 +25,11 @@ function CharacterMounts() {
 		<div className='mount-details'>
 			<header>Mount Details</header>
 			{charMounts ? (
-				charMounts.map((mount) => {
-					return <MountIndexItem key={mount.id} mount={mount} />;
-				})
+				<ul>
+					{charMounts.map((mount) => {
+						return <MountIndexItem key={mount.id} mount={mount} />;
+					})}
+				</ul>
 			) : (
 				<p>Fetching Mounts...</p>
 			)}

--- a/src/components/CharacterMounts.js
+++ b/src/components/CharacterMounts.js
@@ -1,0 +1,38 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchMounts } from '../store/mounts';
+import MountIndexItem from './MountIndexItem';
+import '../styles/CharacterMounts.scss';
+
+function CharacterMounts() {
+	const dispatch = useDispatch();
+	const currentCharKey = useSelector((state) => state.session.currentChar);
+	const currentChar = useSelector((state) => state.characters[currentCharKey]);
+	const charMounts = useSelector((state) => state.mounts[currentCharKey]);
+	const oAuth = useSelector((state) => state.session.oAuth);
+
+	useEffect(
+		() => {
+			// Prevents refetching of mounts if already present in Redux store
+			if (!charMounts) {
+				dispatch(fetchMounts(currentChar.region, currentChar.realm.slug, currentChar.name.toLowerCase(), oAuth));
+			}
+		},
+		[ dispatch, oAuth, currentChar, charMounts ]
+	);
+
+	return (
+		<div className='mount-details'>
+			<header>Mount Details</header>
+			{charMounts ? (
+				charMounts.map((mount) => {
+					return <MountIndexItem key={mount.id} mount={mount} />;
+				})
+			) : (
+				<p>Fetching Mounts...</p>
+			)}
+		</div>
+	);
+}
+
+export default CharacterMounts;

--- a/src/components/MountIndexItem.js
+++ b/src/components/MountIndexItem.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchMountData } from '../store/mounts.js';
 import '../styles/MountIndexItem.scss';
 
-function MountIndexItem({ mount: { id, href } }) {
+function MountIndexItem({ mount: { id, name, href } }) {
 	const dispatch = useDispatch();
 	const oAuth = useSelector((state) => state.session.oAuth);
 	const mount = useSelector((state) => state.mounts[id]);
@@ -18,14 +18,20 @@ function MountIndexItem({ mount: { id, href } }) {
 	);
 
 	return mount ? (
-		<div className={`mount-detail ${mount.faction}`}>
-			<img src={mount.media.href} alt={mount.name} className='mount-img' />
+		<li className='mount-index-item'>
 			<a href={`https://www.wowhead.com/mount/${mount.id}`} className='mount-link'>
-				{mount.name}
+				<div className='mount-shadow'>
+					<img src={mount.media.href} alt={mount.name} className='mount-img' />
+					<p className='mount-name'>{mount.name}</p>
+				</div>
 			</a>
-		</div>
+		</li>
 	) : (
-		<p>"Fetching Mount...</p>
+		<li className='mount-index-item'>
+			<a href={`https://www.wowhead.com/mount/${id}`} className='mount-link'>
+				<p className='mount-name'>{name}</p>
+			</a>
+		</li>
 	);
 }
 

--- a/src/components/MountIndexItem.js
+++ b/src/components/MountIndexItem.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchMountData } from '../store/mounts.js';
 import '../styles/MountIndexItem.scss';
 
-function MountIndexItem({ mount: { id, name, href } }) {
+function MountIndexItem({ mount: { id, name } }) {
 	const dispatch = useDispatch();
 	const oAuth = useSelector((state) => state.session.oAuth);
 	const mount = useSelector((state) => state.mounts[id]);
@@ -11,12 +11,15 @@ function MountIndexItem({ mount: { id, name, href } }) {
 	useEffect(
 		() => {
 			if (!mount) {
-				dispatch(fetchMountData(href, oAuth));
+				dispatch(fetchMountData(id, oAuth));
 			}
 		},
-		[ mount, href, oAuth, dispatch ]
+		[ mount, id, oAuth, dispatch ]
 	);
 
+	// The mount represents the fully populated data after the fetch for details
+	// If this isn't present, we can use the basic mount name and id from props,
+	// but no media will be shown.
 	return mount ? (
 		<li className='mount-index-item'>
 			<a href={`https://www.wowhead.com/mount/${mount.id}`} className='mount-link'>
@@ -29,7 +32,9 @@ function MountIndexItem({ mount: { id, name, href } }) {
 	) : (
 		<li className='mount-index-item'>
 			<a href={`https://www.wowhead.com/mount/${id}`} className='mount-link'>
-				<p className='mount-name'>{name}</p>
+				<div className='mount-shadow'>
+					<p className='mount-name'>{name}</p>
+				</div>
 			</a>
 		</li>
 	);

--- a/src/components/MountIndexItem.js
+++ b/src/components/MountIndexItem.js
@@ -1,0 +1,32 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchMountData } from '../store/mounts.js';
+import '../styles/MountIndexItem.scss';
+
+function MountIndexItem({ mount: { id, href } }) {
+	const dispatch = useDispatch();
+	const oAuth = useSelector((state) => state.session.oAuth);
+	const mount = useSelector((state) => state.mounts[id]);
+
+	useEffect(
+		() => {
+			if (!mount) {
+				dispatch(fetchMountData(href, oAuth));
+			}
+		},
+		[ mount, href, oAuth, dispatch ]
+	);
+
+	return mount ? (
+		<div className={`mount-detail ${mount.faction}`}>
+			<img src={mount.media.href} alt={mount.name} className='mount-img' />
+			<a href={`https://www.wowhead.com/mount/${mount.id}`} className='mount-link'>
+				{mount.name}
+			</a>
+		</div>
+	) : (
+		<p>"Fetching Mount...</p>
+	);
+}
+
+export default MountIndexItem;

--- a/src/store/defaults.js
+++ b/src/store/defaults.js
@@ -52,4 +52,19 @@ export const defaultChar = {
 	}
 };
 
-export const defaultStore = { characters: defaultChar, gear: defaultGear };
+export const defaultMounts = {
+	bryce_morgan: [
+		{
+			id: 1039,
+			name: 'Mighty Caravan Brutosaur',
+			is_useable: true
+		},
+		{
+			id: 1442,
+			name: 'Corridor Creeper',
+			is_useable: true
+		}
+	]
+};
+
+export const defaultStore = { characters: defaultChar, gear: defaultGear, mounts: defaultMounts };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,13 +2,15 @@ import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import { characterReducer } from './characters';
 import { gearReducer } from './gear';
+import { mountReducer } from './mounts';
 
 import { sessionReducer } from './session';
 
 const rootReducer = combineReducers({
 	session: sessionReducer,
 	characters: characterReducer,
-	gear: gearReducer
+	gear: gearReducer,
+	mounts: mountReducer
 });
 
 let enhancer;

--- a/src/store/mounts.js
+++ b/src/store/mounts.js
@@ -1,0 +1,53 @@
+import { selectCharMountData, selectMountDetails } from './selectors';
+
+export const RECEIVE_CHAR_MOUNTS = 'RECEIVE_CHAR_MOUNTS';
+export const RECEIVE_MOUNT_DETAILS = 'RECEIVE_MOUNT_DETAILS';
+
+export const receiveMounts = (key, data) => {
+	return {
+		type: RECEIVE_CHAR_MOUNTS,
+		key,
+		data
+	};
+};
+
+export const receiveMountDetails = (data) => {
+	return {
+		type: RECEIVE_MOUNT_DETAILS,
+		data
+	};
+};
+
+// Fetches which mounts a character owns from Blizzard API
+export const fetchMounts = (region, realm, name, oAuth) => async (dispatch) => {
+	const mountRes = await fetch(
+		`https://${region}.api.blizzard.com/profile/wow/character/${realm}/${name}/collections/mounts?namespace=profile-${region}&locale=en_US&access_token=${oAuth}`
+	);
+	const mountData = await mountRes.json();
+	const selectedData = selectCharMountData(mountData);
+
+	// A unique character key is generated combining the region, realm, and name
+	// This is used in multiple slices of the Redux store to retrieve cached data
+	const charKey = `${region}_${realm}_${name}`;
+	dispatch(receiveMounts(charKey, selectedData));
+	return selectedData;
+};
+
+// Fetches data about a specific mount (media, faction, etc.) from Blizzard API
+export const fetchMountData = (href, oAuth) => async (dispatch) => {
+	const mountRes = await fetch(`${href}&locale=en_US&access_token=${oAuth}`);
+	const mountData = await mountRes.json();
+	const selectedData = await selectMountDetails(mountData, oAuth);
+	dispatch(receiveMountDetails(selectedData));
+};
+
+export const mountReducer = (state = {}, action) => {
+	switch (action.type) {
+		case RECEIVE_CHAR_MOUNTS:
+			return { ...state, [action.key]: action.data };
+		case RECEIVE_MOUNT_DETAILS:
+			return { ...state, [action.data.id]: action.data };
+		default:
+			return state;
+	}
+};

--- a/src/store/mounts.js
+++ b/src/store/mounts.js
@@ -1,4 +1,5 @@
 import { selectCharMountData, selectMountDetails } from './selectors';
+import { sleep } from '../utility.js';
 
 export const RECEIVE_CHAR_MOUNTS = 'RECEIVE_CHAR_MOUNTS';
 export const RECEIVE_MOUNT_DETAILS = 'RECEIVE_MOUNT_DETAILS';
@@ -34,10 +35,29 @@ export const fetchMounts = (region, realm, name, oAuth) => async (dispatch) => {
 };
 
 // Fetches data about a specific mount (media, faction, etc.) from Blizzard API
-export const fetchMountData = (href, oAuth) => async (dispatch) => {
-	const mountRes = await fetch(`${href}&locale=en_US&access_token=${oAuth}`);
+export const fetchMountData = (id, oAuth) => async (dispatch) => {
+	// Discovered that the href from the initial character mounts fetch cannot be used
+	// Reasoning is due to the namespace in the href, which is specific to the last
+	// login of the character. If a character has not logged in recently, the old
+	// patch number is still included in the namespace and the data cannot be fetched
+	// from the Blizzard API.
+	// Here we construct our own request with the generic 'static-' namespace so that
+	// data can be fetched on characters that have not recently logged in.
+	const mountRes = await fetch(
+		`https://us.api.blizzard.com/data/wow/mount/${id}?namespace=static-us&locale=en_US&access_token=${oAuth}`
+	);
 	const mountData = await mountRes.json();
-	const selectedData = await selectMountDetails(mountData, oAuth);
+
+	// A sleep is implemented to avoid timing out from too many requests to the Blizzard API
+	await sleep(100);
+
+	const mediaRes = await fetch(
+		`https://us.api.blizzard.com/data/wow/media/creature-display/${mountData.creature_displays[0]
+			.id}?namespace=static-us&locale=en_US&access_token=${oAuth}`
+	);
+	const mediaData = await mediaRes.json();
+	const selectedData = await selectMountDetails(mountData, mediaData);
+
 	dispatch(receiveMountDetails(selectedData));
 };
 

--- a/src/store/selectors.js
+++ b/src/store/selectors.js
@@ -68,7 +68,7 @@ export function selectCharMountData(body) {
 
 // Strips the large object of mount data to only that which will be used by the app
 export async function selectMountDetails(body, oAuth) {
-	await sleep(100);
+	await sleep(150);
 	const mediaRes = await fetch(`${body.creature_displays[0].key.href}&locale=en_US&access_token=${oAuth}`);
 	const mediaParsed = await mediaRes.json();
 	const avatar = mediaParsed.assets[0].value;

--- a/src/store/selectors.js
+++ b/src/store/selectors.js
@@ -1,3 +1,5 @@
+import { sleep } from '../utility.js';
+
 // Strips the large character and media objects down to data that will be used by the app
 export function selectCharInfo(region, charData, media) {
 	const assets = {};
@@ -52,6 +54,35 @@ export function selectGearData(body) {
 		};
 	});
 	return gearData;
+}
+
+// Strips the large object of mount data to only that which will be used by the app
+export function selectCharMountData(body) {
+	return body.mounts.map(({ mount, is_useable }) => ({
+		id: mount.id,
+		name: mount.name,
+		href: mount.key.href,
+		is_useable
+	}));
+}
+
+// Strips the large object of mount data to only that which will be used by the app
+export async function selectMountDetails(body, oAuth) {
+	await sleep(100);
+	const mediaRes = await fetch(`${body.creature_displays[0].key.href}&locale=en_US&access_token=${oAuth}`);
+	const mediaParsed = await mediaRes.json();
+	const avatar = mediaParsed.assets[0].value;
+
+	return {
+		id: body.id,
+		name: body.name,
+		description: body.description,
+		faction: body.faction ? body.faction.name : 'No Faction',
+		media: {
+			id: body.creature_displays[0].id,
+			href: avatar
+		}
+	};
 }
 
 // Strips realm data object to dev-friendly array of objects representing the name and slug

--- a/src/store/selectors.js
+++ b/src/store/selectors.js
@@ -1,5 +1,3 @@
-import { sleep } from '../utility.js';
-
 // Strips the large character and media objects down to data that will be used by the app
 export function selectCharInfo(region, charData, media) {
 	const assets = {};
@@ -61,26 +59,20 @@ export function selectCharMountData(body) {
 	return body.mounts.map(({ mount, is_useable }) => ({
 		id: mount.id,
 		name: mount.name,
-		href: mount.key.href,
 		is_useable
 	}));
 }
 
-// Strips the large object of mount data to only that which will be used by the app
-export async function selectMountDetails(body, oAuth) {
-	await sleep(150);
-	const mediaRes = await fetch(`${body.creature_displays[0].key.href}&locale=en_US&access_token=${oAuth}`);
-	const mediaParsed = await mediaRes.json();
-	const avatar = mediaParsed.assets[0].value;
-
+//  Strips, reformats, and combines mount details and media to relevent data
+export async function selectMountDetails(mountData, mediaData) {
 	return {
-		id: body.id,
-		name: body.name,
-		description: body.description,
-		faction: body.faction ? body.faction.name : 'No Faction',
+		id: mountData.id,
+		name: mountData.name,
+		description: mountData.description,
+		faction: mountData.faction ? mountData.faction.name : 'NoFaction',
 		media: {
-			id: body.creature_displays[0].id,
-			href: avatar
+			id: mountData.creature_displays[0].id,
+			href: mediaData.assets[0].value
 		}
 	};
 }

--- a/src/styles/CharacterDetails.scss
+++ b/src/styles/CharacterDetails.scss
@@ -23,6 +23,26 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
+
+		.detail-select-nav {
+			font-size: 20px;
+			height: 30px;
+			margin-top: 5px;
+			display: flex;
+			flex-direction: row;
+			button {
+				border: 1px solid black;
+				background-color: $midbackground;
+				color: white;
+				box-shadow: 0px 0px 2px white inset;
+				padding: 2px 5px;
+
+				&.active {
+					color: black;
+					background-color: grey;
+				}
+			}
+		}
 	}
 
 	.character-model {

--- a/src/styles/CharacterMounts.scss
+++ b/src/styles/CharacterMounts.scss
@@ -1,0 +1,26 @@
+@import './variables.scss';
+
+.mount-details {
+	width: 70%;
+	min-width: 300px;
+	padding: 5px;
+	border: 1px solid black;
+	background-color: $midbackground;
+	max-height: 60%;
+	margin: 10px 10px 0px 5px;
+	color: white;
+	box-shadow: inset 0px 0px 2px white;
+	border-radius: 2px;
+
+	header {
+		text-align: center;
+		font-size: 20px;
+		border-bottom: 1px solid black;
+		margin-bottom: 5px;
+	}
+
+	ul {
+		height: calc(100% - 25px);
+		overflow-y: auto;
+	}
+}

--- a/src/styles/MountIndexItem.scss
+++ b/src/styles/MountIndexItem.scss
@@ -1,0 +1,57 @@
+@import './variables.scss';
+
+.mount-index-item {
+	width: 100%;
+	border: 1px solid black;
+	background-color: $midbackground;
+	box-shadow: 0px 0px 2px white inset;
+	position: relative;
+	transition-duration: 1s;
+	cursor: pointer;
+
+	.mount-shadow {
+		z-index: 2;
+		display: flex;
+		align-items: center;
+
+		.mount-img {
+			width: 40%;
+			height: auto;
+			z-index: 2;
+		}
+
+		.mount-name {
+			margin-left: 5px;
+			z-index: 2;
+			cursor: pointer;
+			font-size: 16px;
+		}
+	}
+
+	&::before {
+		position: absolute;
+		content: "";
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		background-image: linear-gradient(to right, $midbackground, $lightbackground);
+		z-index: -1;
+		opacity: 0;
+	}
+	&:hover {
+		&::before {
+			transition-duration: 0.5s;
+			z-index: 1;
+			opacity: 1;
+		}
+	}
+}
+
+// .mount-link {
+// 	display: flex;
+// 	align-items: center;
+// 	img {
+// 		width: 40%;
+// 	}
+// }

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,0 +1,3 @@
+export function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Adds a feature similar to the gear details box which fetches a character's acquired mounts. Mount media is additionally fetched to display an icon next to mount names. Tooltips are implemented to point to Wowhead mount pages.