### PR TITLE
Raid progression

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -1,9 +1,0 @@
-Fetch instance data for raids (image urls) and store in redux
-Break out instances into own component
-CSS for raid dropdown and instance items
-  - Similar to VSCode drop down? > when closed V when open?
-  - Shadow under dropdown title
-  - Grayed out text when no instances for expansion, Black title when instance data exists?
-  - Image of instance (in circle with border?) above name of instance above progress for each mode (N: 10/10, H: 10/10, M: 7/10 ?)
-  - Image link to wowhead article or guide on instance?
-  - Green text for completed instances, yellow for in progress?

--- a/NEXT.md
+++ b/NEXT.md
@@ -1,0 +1,9 @@
+Fetch instance data for raids (image urls) and store in redux
+Break out instances into own component
+CSS for raid dropdown and instance items
+  - Similar to VSCode drop down? > when closed V when open?
+  - Shadow under dropdown title
+  - Grayed out text when no instances for expansion, Black title when instance data exists?
+  - Image of instance (in circle with border?) above name of instance above progress for each mode (N: 10/10, H: 10/10, M: 7/10 ?)
+  - Image link to wowhead article or guide on instance?
+  - Green text for completed instances, yellow for in progress?

--- a/frontend/src/components/CharacterDetails.js
+++ b/frontend/src/components/CharacterDetails.js
@@ -6,6 +6,7 @@ import CharacterGear from './CharacterGear';
 import CharacterMounts from './CharacterMounts';
 import CharNotFound from './CharacterNotFound';
 import CharacterPets from './CharacterPets';
+import CharacterRaids from './CharacterRaids';
 import Welcome from './Welcome';
 
 function CharacterDetails() {
@@ -16,7 +17,8 @@ function CharacterDetails() {
 	const activeDetailMapping = {
 		gear: <CharacterGear />,
 		mounts: <CharacterMounts />,
-		pets: <CharacterPets />
+		pets: <CharacterPets />,
+		raids: <CharacterRaids />
 	};
 
 	// If a character has been fetched display its data
@@ -47,6 +49,12 @@ currentChar ? (
 						className={activeDetail === 'pets' ? 'border detail-select active' : 'border detail-select'}
 					>
 						Display Pets
+					</button>
+					<button
+						onClick={() => setActiveDetail('raids')}
+						className={activeDetail === 'raids' ? 'border detail-select active' : 'border detail-select'}
+					>
+						Display Raids
 					</button>
 				</nav>
 				{activeDetailMapping[activeDetail]}

--- a/frontend/src/components/CharacterGear.js
+++ b/frontend/src/components/CharacterGear.js
@@ -28,7 +28,7 @@ function CharacterGear() {
 					return (
 						<p key={slot}>
 							{slot}:{' '}
-							<a href={`https://www.wowhead.com/item=${data.id}&ilvl=${data.ilvl}`} className={data.quality}>
+							<a href={`https://www.wowhead.com/item=${data.id}&ilvl=${data.ilvl}`} target='_blank' rel='noreferrer' className={data.quality}>
 								{`${data.name} (${data.ilvl})`}
 							</a>
 						</p>

--- a/frontend/src/components/CharacterRaids.js
+++ b/frontend/src/components/CharacterRaids.js
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchRaids } from '../store/raids';
 import RaidExpansionDropdown from './RaidExpansionDropdown';
+import '../styles/CharacterRaids.scss'
 
 function CharacterRaids() {
 	const dispatch = useDispatch();
@@ -24,13 +25,11 @@ function CharacterRaids() {
 		<div className='raid-details border'>
 			<header>Raid Details</header>
 			{charRaids ? (
-				<>
 				<ul>
           {Object.entries(charRaids).map(([expansionName, expansion]) => {
             return <RaidExpansionDropdown expansion={expansion} expansionName={expansionName} key={expansionName} />
           })}
 				</ul>
-				</>
 			) : (
 				<p>Fetching Raids...</p>
 			)}

--- a/frontend/src/components/CharacterRaids.js
+++ b/frontend/src/components/CharacterRaids.js
@@ -20,7 +20,6 @@ function CharacterRaids() {
 		[ dispatch, oAuth, currentChar, charRaids ]
 	);
 
-  if (charRaids) console.log(charRaids);
 	return (
 		<div className='raid-details border'>
 			<header>Raid Details</header>

--- a/frontend/src/components/CharacterRaids.js
+++ b/frontend/src/components/CharacterRaids.js
@@ -1,0 +1,62 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchRaids } from '../store/raids';
+
+function CharacterRaids() {
+	const dispatch = useDispatch();
+	const currentCharKey = useSelector((state) => state.session.currentChar);
+	const currentChar = useSelector((state) => state.characters[currentCharKey]);
+	const charRaids = useSelector((state) => state.raids[currentCharKey]);
+	const oAuth = useSelector((state) => state.session.oAuth);
+
+	useEffect(
+		() => {
+			// Prevents refetching of raids if already present in Redux store
+			if (!charRaids) {
+				dispatch(fetchRaids(currentChar.region, currentChar.realm.slug, currentChar.name.toLowerCase(), oAuth));
+			}
+		},
+		[ dispatch, oAuth, currentChar, charRaids ]
+	);
+
+	// // If a user has submitted content in the textbox, filter raids by names that include that content
+  if (charRaids) console.log(charRaids);
+	return (
+		<div className='raid-details border'>
+			<header>Raid Details</header>
+			{charRaids ? (
+				<>
+				<ul>
+          {Object.entries(charRaids).map(([expansionName, expansion]) => {
+            return <li key={expansion.id || expansionName}>
+              <div>
+                <p>{expansionName}</p>
+                { expansion.instances ? 
+                  <ul>
+                    {Object.entries(expansion.instances).map(([instanceName, instance]) => {
+                      return <li key={instance.id}>
+                        <div>
+                          <p>{instanceName}</p>
+                          <div>
+                            {Object.entries(instance.modes).map(([modeName, mode]) => {
+                              return <p key={modeName}>{modeName} - {mode.progress.completed}/{mode.progress.total}</p>
+                            })}
+                          </div>
+                        </div>
+                      </li>
+                    })}
+                  </ul> : null
+                }
+              </div>
+            </li>
+          })}
+				</ul>
+				</>
+			) : (
+				<p>Fetching Raids...</p>
+			)}
+		</div>
+	);
+}
+
+export default CharacterRaids;

--- a/frontend/src/components/CharacterRaids.js
+++ b/frontend/src/components/CharacterRaids.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchRaids } from '../store/raids';
+import RaidExpansionDropdown from './RaidExpansionDropdown';
 
 function CharacterRaids() {
 	const dispatch = useDispatch();
@@ -19,7 +20,6 @@ function CharacterRaids() {
 		[ dispatch, oAuth, currentChar, charRaids ]
 	);
 
-	// // If a user has submitted content in the textbox, filter raids by names that include that content
   if (charRaids) console.log(charRaids);
 	return (
 		<div className='raid-details border'>
@@ -28,27 +28,7 @@ function CharacterRaids() {
 				<>
 				<ul>
           {Object.entries(charRaids).map(([expansionName, expansion]) => {
-            return <li key={expansion.id || expansionName}>
-              <div>
-                <p>{expansionName}</p>
-                { expansion.instances ? 
-                  <ul>
-                    {Object.entries(expansion.instances).map(([instanceName, instance]) => {
-                      return <li key={instance.id}>
-                        <div>
-                          <p>{instanceName}</p>
-                          <div>
-                            {Object.entries(instance.modes).map(([modeName, mode]) => {
-                              return <p key={modeName}>{modeName} - {mode.progress.completed}/{mode.progress.total}</p>
-                            })}
-                          </div>
-                        </div>
-                      </li>
-                    })}
-                  </ul> : null
-                }
-              </div>
-            </li>
+            return <RaidExpansionDropdown expansion={expansion} expansionName={expansionName} key={expansionName} />
           })}
 				</ul>
 				</>

--- a/frontend/src/components/MountIndexItem.js
+++ b/frontend/src/components/MountIndexItem.js
@@ -21,7 +21,7 @@ function MountIndexItem({ mount: { id, name } }) {
 	// we use only have the basic data passed from props.
 	return (
 		<li className='index-item border'>
-			<a href={`https://www.wowhead.com/mount/${id}`} className='index-link'>
+			<a href={`https://www.wowhead.com/mount/${id}`} target='_blank' rel='noreferrer' className='index-link'>
 				<div className='index-shadow'>
 					{mount && <img src={mount.media.href} alt={name} className='index-img mount' />}
 					<p className='index-name'>{name}</p>

--- a/frontend/src/components/PetIndexItem.js
+++ b/frontend/src/components/PetIndexItem.js
@@ -25,7 +25,7 @@ function PetIndexItem({ pet: { speciesId, speciesName, nickname, level, quality,
 	// if this failure occurs
 	return (
 		<li className='index-item border'>
-			<a href={`https://www.wowhead.com/battle-pet/${speciesId}`} className='index-link'>
+			<a href={`https://www.wowhead.com/battle-pet/${speciesId}`} target='_blank' rel='noreferrer' className='index-link'>
 				<div className='index-shadow'>
 					{isFavorite && <FontAwesomeIcon className='favorite-star' icon={faStar} />}
 					{pet && <img src={pet.media.href || pet.media.icon} alt={speciesName} className='index-img pet' />}

--- a/frontend/src/components/RaidExpansionDropdown.js
+++ b/frontend/src/components/RaidExpansionDropdown.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import RaidInstanceIndexItem from './RaidInstanceIndexItem';
 
 function RaidExpansionDropdown({expansion, expansionName}) {
 	const [ isOpen, setIsOpen ] = useState(false);
@@ -12,16 +13,7 @@ function RaidExpansionDropdown({expansion, expansionName}) {
             { 
               Object.entries(expansion.instances).map(([instanceName, instance]) => {
                 return (
-                  <li key={instance.id}>
-                    <div className='index-shadow'>
-                      <p className='index-name'>{instanceName}</p>
-                      <div>
-                        {Object.entries(instance.modes).map(([modeName, mode]) => {
-                          return <p key={modeName}>{modeName} - {mode.progress.completed}/{mode.progress.total}</p>
-                        })}
-                      </div>
-                    </div>
-                  </li>
+                  <RaidInstanceIndexItem key={instanceName} instance={instance}/>
                 )
               })
             }

--- a/frontend/src/components/RaidExpansionDropdown.js
+++ b/frontend/src/components/RaidExpansionDropdown.js
@@ -1,15 +1,22 @@
 import React, { useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCaretDown, faCaretRight } from '@fortawesome/free-solid-svg-icons'
 import RaidInstanceIndexItem from './RaidInstanceIndexItem';
 
 function RaidExpansionDropdown({expansion, expansionName}) {
 	const [ isOpen, setIsOpen ] = useState(false);
 
+  const caret = isOpen ? faCaretDown : faCaretRight;
+
 	return (
     <li className={'index-item border'.concat(isOpen ? ' open' : '')}>
-      <div className='index-shadow'>
-        <p className='index-name' onClick={() => setIsOpen(!isOpen)}>{expansionName}</p>
+      <div className='index-shadow raid'>
+        <div className='title-container' onClick={() => setIsOpen(!isOpen)}>
+          <FontAwesomeIcon className='caret' icon={caret} />
+          <p className='index-name'>{expansionName}</p>
+        </div>
         { isOpen && ( expansion.instances ? 
-          <ul>
+          <div className='expansion-instance-container'>
             { 
               Object.entries(expansion.instances).map(([instanceName, instance]) => {
                 return (
@@ -17,7 +24,7 @@ function RaidExpansionDropdown({expansion, expansionName}) {
                 )
               })
             }
-          </ul> 
+          </div> 
           : 
           <div>
             <p>No raid data for this expansion</p>

--- a/frontend/src/components/RaidExpansionDropdown.js
+++ b/frontend/src/components/RaidExpansionDropdown.js
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+
+function RaidExpansionDropdown({expansion, expansionName}) {
+	const [ isOpen, setIsOpen ] = useState(false);
+
+	return (
+    <li onClick={() => setIsOpen(!isOpen)} className={'index-item border'.concat(isOpen ? ' open' : '')}>
+      <div className='index-shadow'>
+        <p className='index-name'>{expansionName}</p>
+        { isOpen && ( expansion.instances ? 
+          <ul>
+            { 
+              Object.entries(expansion.instances).map(([instanceName, instance]) => {
+                return (
+                  <li key={instance.id}>
+                    <div className='index-shadow'>
+                      <p className='index-name'>{instanceName}</p>
+                      <div>
+                        {Object.entries(instance.modes).map(([modeName, mode]) => {
+                          return <p key={modeName}>{modeName} - {mode.progress.completed}/{mode.progress.total}</p>
+                        })}
+                      </div>
+                    </div>
+                  </li>
+                )
+              })
+            }
+          </ul> 
+          : 
+          <div>
+            <p>No raid data for this expansion</p>
+          </div>
+          )
+        }
+      </div>
+    </li>
+	)
+}
+
+export default RaidExpansionDropdown;

--- a/frontend/src/components/RaidExpansionDropdown.js
+++ b/frontend/src/components/RaidExpansionDropdown.js
@@ -5,9 +5,9 @@ function RaidExpansionDropdown({expansion, expansionName}) {
 	const [ isOpen, setIsOpen ] = useState(false);
 
 	return (
-    <li onClick={() => setIsOpen(!isOpen)} className={'index-item border'.concat(isOpen ? ' open' : '')}>
+    <li className={'index-item border'.concat(isOpen ? ' open' : '')}>
       <div className='index-shadow'>
-        <p className='index-name'>{expansionName}</p>
+        <p className='index-name' onClick={() => setIsOpen(!isOpen)}>{expansionName}</p>
         { isOpen && ( expansion.instances ? 
           <ul>
             { 

--- a/frontend/src/components/RaidInstanceIndexItem.js
+++ b/frontend/src/components/RaidInstanceIndexItem.js
@@ -1,7 +1,9 @@
 import React, { useEffect } from 'react';
+import ReactTooltip from '@huner2/react-tooltip';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchRaidData } from '../store/raids';
 import '../styles/DetailIndexItem.scss';
+import '../styles/RaidInstanceIndexItem.scss';
 
 function RaidInstanceIndexItem({ instance: { id, name, modes } }) {
 	const dispatch = useDispatch();
@@ -20,21 +22,18 @@ function RaidInstanceIndexItem({ instance: { id, name, modes } }) {
 	// If we've fetched the additional raid data, we can show the media, otherwise
 	// we use only have the basic data passed from props.
 	return (
-    <li>
-      <div className='index-shadow'>
-        <p className='index-name'>{name}</p>
-        <div>
-          { raid && 
-            <a href={`https://www.wowhead.com/${raid.wowheadTitle}`} target='_blank' rel='noreferrer' className='index-link'>
-              <img src={raid.media.href} alt={name} className='index-img mount' />
-            </a>
-          }
-          {Object.entries(modes).map(([modeName, mode]) => {
-            return <p key={modeName}>{modeName} - {mode.progress.completed}/{mode.progress.total}</p>
-          })}
-        </div>
-      </div>
-    </li>
+    <div className='instance-container'>
+      { raid && 
+        <a href={`https://www.wowhead.com/${raid.wowheadTitle}`} target='_blank' rel='noreferrer' className='index-link'>
+          <img data-tip={'Wowhead article for ' + name} src={raid.media.href} alt={name} className='index-img raid' />
+          <ReactTooltip place='top' effect='solid' />
+        </a>
+      }
+      <p className='index-name'>{name}</p>
+      {Object.entries(modes).map(([modeName, mode]) => {
+        return <p key={modeName} className={mode.status}>{modeName} - {mode.progress.completed}/{mode.progress.total}</p>
+      })}
+    </div>
 	);
 }
 

--- a/frontend/src/components/RaidInstanceIndexItem.js
+++ b/frontend/src/components/RaidInstanceIndexItem.js
@@ -17,14 +17,18 @@ function RaidInstanceIndexItem({ instance: { id, name, modes } }) {
 		[ raid, id, oAuth, dispatch ]
 	);
 
-	// If we've fetched the additional mount data, we can show the media, otherwise
+	// If we've fetched the additional raid data, we can show the media, otherwise
 	// we use only have the basic data passed from props.
 	return (
     <li>
       <div className='index-shadow'>
         <p className='index-name'>{name}</p>
         <div>
-          {raid && <img src={raid.media.href} alt={name} className='index-img mount' />}
+          { raid && 
+            <a href={`https://www.wowhead.com/${raid.wowheadTitle}`} target='_blank' rel='noreferrer' className='index-link'>
+              <img src={raid.media.href} alt={name} className='index-img mount' />
+            </a>
+          }
           {Object.entries(modes).map(([modeName, mode]) => {
             return <p key={modeName}>{modeName} - {mode.progress.completed}/{mode.progress.total}</p>
           })}

--- a/frontend/src/components/RaidInstanceIndexItem.js
+++ b/frontend/src/components/RaidInstanceIndexItem.js
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchRaidData } from '../store/raids';
+import '../styles/DetailIndexItem.scss';
+
+function RaidInstanceIndexItem({ instance: { id, name, modes } }) {
+	const dispatch = useDispatch();
+	const oAuth = useSelector((state) => state.session.oAuth);
+	const raid = useSelector((state) => state.raids[id]);
+
+	useEffect(
+		() => {
+			if (!raid) {
+				dispatch(fetchRaidData(id, oAuth));
+			}
+		},
+		[ raid, id, oAuth, dispatch ]
+	);
+
+	// If we've fetched the additional mount data, we can show the media, otherwise
+	// we use only have the basic data passed from props.
+	return (
+    <li>
+      <div className='index-shadow'>
+        <p className='index-name'>{name}</p>
+        <div>
+          {raid && <img src={raid.media.href} alt={name} className='index-img mount' />}
+          {Object.entries(modes).map(([modeName, mode]) => {
+            return <p key={modeName}>{modeName} - {mode.progress.completed}/{mode.progress.total}</p>
+          })}
+        </div>
+      </div>
+    </li>
+	);
+}
+
+export default RaidInstanceIndexItem;

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -29,7 +29,7 @@ function Welcome() {
 				<ul className='future-capabilities'>
 					<li className='completed'>Collection information, such as pets and mounts (Completed!)</li>
 					<li className='completed'>Flask backend to support developer key security (Completed!)</li>
-					<li>Character raid progression</li>
+					<li className='completed'>Character raid progression (Completed!)</li>
 					<li>Character dungeon and mythic+ data</li>
 					<li>User account creation, database storage, and saving of characters</li>
 				</ul>

--- a/frontend/src/store/TEMP_SAMPLE_RAID_DATA.json
+++ b/frontend/src/store/TEMP_SAMPLE_RAID_DATA.json
@@ -1,0 +1,2408 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/profile/wow/character/zuljin/pesteil/encounters/raids?namespace=profile-us"
+    }
+  },
+  "character": {
+    "key": {
+      "href": "https://us.api.blizzard.com/profile/wow/character/zuljin/pesteil?namespace=profile-us"
+    },
+    "name": "Pesteil",
+    "id": 191313780,
+    "realm": {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/realm/61?namespace=dynamic-us"
+      },
+      "name": "Zul'jin",
+      "id": 61,
+      "slug": "zuljin"
+    }
+  },
+  "expansions": [
+    {
+      "expansion": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/journal-expansion/68?namespace=static-9.1.0_39069-us"
+        },
+        "name": "Classic",
+        "id": 68
+      },
+      "instances": [
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/743?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Ruins of Ahn'Qiraj",
+            "id": 743
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LEGACY_10_MAN",
+                "name": "10 Player"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 1,
+                "total_count": 1,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1542?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Ossirian the Unscarred",
+                      "id": 1542
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1531320838000
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/744?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Temple of Ahn'Qiraj",
+            "id": 744
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "NORMAL",
+                "name": "Normal"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 1,
+                "total_count": 1,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1551?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "C'Thun",
+                      "id": 1551
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1531325037000
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "expansion": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/journal-expansion/70?namespace=static-9.1.0_39069-us"
+        },
+        "name": "Burning Crusade",
+        "id": 70
+      },
+      "instances": [
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/749?namespace=static-9.1.0_39069-us"
+            },
+            "name": "The Eye",
+            "id": 749
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN",
+                "name": "25 Player"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 1,
+                "total_count": 1,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1576?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Kael'thas Sunstrider",
+                      "id": 1576
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602405528000
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "expansion": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/journal-expansion/72?namespace=static-9.1.0_39069-us"
+        },
+        "name": "Wrath of the Lich King",
+        "id": 72
+      },
+      "instances": [
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/753?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Vault of Archavon",
+            "id": 753
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN",
+                "name": "25 Player"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 4,
+                "total_count": 4,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1597?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Archavon the Stone Watcher",
+                      "id": 1597
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1606105990000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1598?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Emalon the Storm Watcher",
+                      "id": 1598
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1606105855000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1599?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Koralon the Flame Watcher",
+                      "id": 1599
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1606105790000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1600?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Toravon the Ice Watcher",
+                      "id": 1600
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1606105937000
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/755?namespace=static-9.1.0_39069-us"
+            },
+            "name": "The Obsidian Sanctum",
+            "id": 755
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN",
+                "name": "25 Player"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 1,
+                "total_count": 1,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1616?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Sartharion",
+                      "id": 1616
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1527736122000
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/757?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Trial of the Crusader",
+            "id": 757
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN",
+                "name": "25 Player"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 5,
+                "total_count": 5,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1618?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Northrend Beasts",
+                      "id": 1618
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1606041546000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1619?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Lord Jaraxxus",
+                      "id": 1619
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1606041665000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1620?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Champions of the Alliance",
+                      "id": 1620
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1606041814000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1622?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Twin Val'kyr",
+                      "id": 1622
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1606041895000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1623?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Anub'arak",
+                      "id": 1623
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1606042027000
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/758?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Icecrown Citadel",
+            "id": 758
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN",
+                "name": "25 Player"
+              },
+              "status": {
+                "type": "IN_PROGRESS",
+                "name": "In Progress"
+              },
+              "progress": {
+                "completed_count": 11,
+                "total_count": 12,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1624?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Lord Marrowgar",
+                      "id": 1624
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600490545000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1625?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Lady Deathwhisper",
+                      "id": 1625
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600490599000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1627?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Icecrown Gunship Battle",
+                      "id": 1627
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600490904000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1628?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Deathbringer Saurfang",
+                      "id": 1628
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600491090000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1629?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Festergut",
+                      "id": 1629
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600491396000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1630?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Rotface",
+                      "id": 1630
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600491293000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1631?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Professor Putricide",
+                      "id": 1631
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600491515000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1632?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Blood Prince Council",
+                      "id": 1632
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600491672000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1633?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Blood-Queen Lana'thel",
+                      "id": 1633
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600492489000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1635?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Sindragosa",
+                      "id": 1635
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600492192000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1636?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Lich King",
+                      "id": 1636
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600492790000
+                  }
+                ]
+              }
+            },
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN_HEROIC",
+                "name": "25 Player (Heroic)"
+              },
+              "status": {
+                "type": "IN_PROGRESS",
+                "name": "In Progress"
+              },
+              "progress": {
+                "completed_count": 11,
+                "total_count": 12,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1624?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Lord Marrowgar",
+                      "id": 1624
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1606001316000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1625?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Lady Deathwhisper",
+                      "id": 1625
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1606001413000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1627?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Icecrown Gunship Battle",
+                      "id": 1627
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1606001580000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1628?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Deathbringer Saurfang",
+                      "id": 1628
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1606001741000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1629?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Festergut",
+                      "id": 1629
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1606001994000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1630?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Rotface",
+                      "id": 1630
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1606001910000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1631?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Professor Putricide",
+                      "id": 1631
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1606002081000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1632?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Blood Prince Council",
+                      "id": 1632
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1606002266000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1633?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Blood-Queen Lana'thel",
+                      "id": 1633
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1606002356000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1635?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Sindragosa",
+                      "id": 1635
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1606002868000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1636?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Lich King",
+                      "id": 1636
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1606003199000
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/760?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Onyxia's Lair",
+            "id": 760
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LEGACY_10_MAN",
+                "name": "10 Player"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 1,
+                "total_count": 1,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1651?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Onyxia",
+                      "id": 1651
+                    },
+                    "completed_count": 12,
+                    "last_kill_timestamp": 1613011804000
+                  }
+                ]
+              }
+            },
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN",
+                "name": "25 Player"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 1,
+                "total_count": 1,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1651?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Onyxia",
+                      "id": 1651
+                    },
+                    "completed_count": 12,
+                    "last_kill_timestamp": 1613011804000
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "expansion": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/journal-expansion/73?namespace=static-9.1.0_39069-us"
+        },
+        "name": "Cataclysm",
+        "id": 73
+      },
+      "instances": [
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/74?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Throne of the Four Winds",
+            "id": 74
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN",
+                "name": "25 Player"
+              },
+              "status": {
+                "type": "IN_PROGRESS",
+                "name": "In Progress"
+              },
+              "progress": {
+                "completed_count": 1,
+                "total_count": 2,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/154?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Conclave of Wind",
+                      "id": 154
+                    },
+                    "completed_count": 2,
+                    "last_kill_timestamp": 1533701408000
+                  }
+                ]
+              }
+            },
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN_HEROIC",
+                "name": "25 Player (Heroic)"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 2,
+                "total_count": 2,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/154?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Conclave of Wind",
+                      "id": 154
+                    },
+                    "completed_count": 6,
+                    "last_kill_timestamp": 1604881623000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/155?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Al'Akir",
+                      "id": 155
+                    },
+                    "completed_count": 8,
+                    "last_kill_timestamp": 1604881665000
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/187?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Dragon Soul",
+            "id": 187
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LEGACY_10_MAN_HEROIC",
+                "name": "10 Player (Heroic)"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 8,
+                "total_count": 8,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/311?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Morchok",
+                      "id": 311
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1531327819000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/324?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Warlord Zon'ozz",
+                      "id": 324
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1531327956000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/325?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Yor'sahj the Unsleeping",
+                      "id": 325
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1531328104000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/317?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Hagara the Stormbinder",
+                      "id": 317
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1531328356000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/331?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Ultraxion",
+                      "id": 331
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1531328710000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/332?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Warmaster Blackhorn",
+                      "id": 332
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1531329096000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/318?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Spine of Deathwing",
+                      "id": 318
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1531330965000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/333?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Madness of Deathwing",
+                      "id": 333
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1531331451000
+                  }
+                ]
+              }
+            },
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN_HEROIC",
+                "name": "25 Player (Heroic)"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 8,
+                "total_count": 8,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/311?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Morchok",
+                      "id": 311
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1533990641000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/324?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Warlord Zon'ozz",
+                      "id": 324
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1533990856000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/325?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Yor'sahj the Unsleeping",
+                      "id": 325
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1533990949000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/317?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Hagara the Stormbinder",
+                      "id": 317
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1533991254000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/331?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Ultraxion",
+                      "id": 331
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1533991612000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/332?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Warmaster Blackhorn",
+                      "id": 332
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1533991933000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/318?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Spine of Deathwing",
+                      "id": 318
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1533992475000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/333?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Madness of Deathwing",
+                      "id": 333
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1533992821000
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "expansion": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/journal-expansion/74?namespace=static-9.1.0_39069-us"
+        },
+        "name": "Mists of Pandaria",
+        "id": 74
+      },
+      "instances": [
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/317?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Mogu'shan Vaults",
+            "id": 317
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN",
+                "name": "25 Player"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 6,
+                "total_count": 6,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/679?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Stone Guard",
+                      "id": 679
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1610443099000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/689?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Feng the Accursed",
+                      "id": 689
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1610443189000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/682?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Gara'jal the Spiritbinder",
+                      "id": 682
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1610443323000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/687?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Spirit Kings",
+                      "id": 687
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1610443499000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/726?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Elegon",
+                      "id": 726
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1610443699000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/677?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Will of the Emperor",
+                      "id": 677
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1610443896000
+                  }
+                ]
+              }
+            },
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN_HEROIC",
+                "name": "25 Player (Heroic)"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 6,
+                "total_count": 6,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/679?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Stone Guard",
+                      "id": 679
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1605764018000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/689?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Feng the Accursed",
+                      "id": 689
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1605764091000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/682?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Gara'jal the Spiritbinder",
+                      "id": 682
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1605764221000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/687?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Spirit Kings",
+                      "id": 687
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1605764418000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/726?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Elegon",
+                      "id": 726
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1605764668000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/677?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Will of the Emperor",
+                      "id": 677
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1605764931000
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/320?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Terrace of Endless Spring",
+            "id": 320
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LEGACY_25_MAN_HEROIC",
+                "name": "25 Player (Heroic)"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 4,
+                "total_count": 4,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/683?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Protectors of the Endless",
+                      "id": 683
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604377452000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/742?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Tsulong",
+                      "id": 742
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604377511000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/729?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Lei Shi",
+                      "id": 729
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604377614000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/709?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Sha of Fear",
+                      "id": 709
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604377700000
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/369?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Siege of Orgrimmar",
+            "id": 369
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LEGACY_10_MAN",
+                "name": "10 Player"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 14,
+                "total_count": 14,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/852?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Immerseus",
+                      "id": 852
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604378207000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/849?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Fallen Protectors",
+                      "id": 849
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604378362000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/866?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Norushen",
+                      "id": 866
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604378573000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/867?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Sha of Pride",
+                      "id": 867
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604378693000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/868?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Galakras",
+                      "id": 868
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604379426000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/864?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Iron Juggernaut",
+                      "id": 864
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604379518000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/856?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Kor'kron Dark Shaman",
+                      "id": 856
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604379895000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/850?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "General Nazgrim",
+                      "id": 850
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604380273000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/846?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Malkorok",
+                      "id": 846
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604380589000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/870?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Spoils of Pandaria",
+                      "id": 870
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604381408000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/851?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Thok the Bloodthirsty",
+                      "id": 851
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604381550000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/865?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Siegecrafter Blackfuse",
+                      "id": 865
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604381885000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/853?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Paragons of the Klaxxi",
+                      "id": 853
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604382152000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/869?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Garrosh Hellscream",
+                      "id": 869
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604382620000
+                  }
+                ]
+              }
+            },
+            {
+              "difficulty": {
+                "type": "LEGACY_10_MAN_HEROIC",
+                "name": "10 Player (Heroic)"
+              },
+              "status": {
+                "type": "IN_PROGRESS",
+                "name": "In Progress"
+              },
+              "progress": {
+                "completed_count": 4,
+                "total_count": 14,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/852?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Immerseus",
+                      "id": 852
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600415299000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/849?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Fallen Protectors",
+                      "id": 849
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600415464000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/866?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Norushen",
+                      "id": 866
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600415758000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/867?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Sha of Pride",
+                      "id": 867
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600416011000
+                  }
+                ]
+              }
+            },
+            {
+              "difficulty": {
+                "type": "HEROIC",
+                "name": "Heroic"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 14,
+                "total_count": 14,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/852?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Immerseus",
+                      "id": 852
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604378207000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/849?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Fallen Protectors",
+                      "id": 849
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604378362000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/866?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Norushen",
+                      "id": 866
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604378573000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/867?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Sha of Pride",
+                      "id": 867
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604378693000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/868?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Galakras",
+                      "id": 868
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604379426000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/864?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Iron Juggernaut",
+                      "id": 864
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604379518000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/856?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Kor'kron Dark Shaman",
+                      "id": 856
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604379895000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/850?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "General Nazgrim",
+                      "id": 850
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604380273000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/846?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Malkorok",
+                      "id": 846
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604380589000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/870?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Spoils of Pandaria",
+                      "id": 870
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604381408000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/851?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Thok the Bloodthirsty",
+                      "id": 851
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604381550000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/865?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Siegecrafter Blackfuse",
+                      "id": 865
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604381885000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/853?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Paragons of the Klaxxi",
+                      "id": 853
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604382152000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/869?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Garrosh Hellscream",
+                      "id": 869
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1604382620000
+                  }
+                ]
+              }
+            },
+            {
+              "difficulty": {
+                "type": "MYTHIC",
+                "name": "Mythic"
+              },
+              "status": {
+                "type": "IN_PROGRESS",
+                "name": "In Progress"
+              },
+              "progress": {
+                "completed_count": 4,
+                "total_count": 14,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/852?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Immerseus",
+                      "id": 852
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600415299000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/849?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Fallen Protectors",
+                      "id": 849
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600415464000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/866?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Norushen",
+                      "id": 866
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600415758000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/867?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Sha of Pride",
+                      "id": 867
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1600416011000
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "expansion": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/journal-expansion/124?namespace=static-9.1.0_39069-us"
+        },
+        "name": "Warlords of Draenor",
+        "id": 124
+      },
+      "instances": [
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/669?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Hellfire Citadel",
+            "id": 669
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "MYTHIC",
+                "name": "Mythic"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 13,
+                "total_count": 13,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1426?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Hellfire Assault",
+                      "id": 1426
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602743444000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1425?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Iron Reaver",
+                      "id": 1425
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602743506000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1392?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Kormrok",
+                      "id": 1392
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602743849000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1432?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Hellfire High Council",
+                      "id": 1432
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602744239000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1396?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Kilrogg Deadeye",
+                      "id": 1396
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602744389000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1372?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Gorefiend",
+                      "id": 1372
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602744665000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1433?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Shadow-Lord Iskar",
+                      "id": 1433
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602744847000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1427?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Socrethar the Eternal",
+                      "id": 1427
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602745368000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1391?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Fel Lord Zakuun",
+                      "id": 1391
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602745015000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1447?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Xhul'horac",
+                      "id": 1447
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602745155000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1394?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Tyrant Velhari",
+                      "id": 1394
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602746344000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1395?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Mannoroth",
+                      "id": 1395
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602746492000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1438?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Archimonde",
+                      "id": 1438
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602746709000
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "expansion": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/journal-expansion/395?namespace=static-9.1.0_39069-us"
+        },
+        "name": "Legion",
+        "id": 395
+      },
+      "instances": [
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/946?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Antorus, the Burning Throne",
+            "id": 946
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "NORMAL",
+                "name": "Normal"
+              },
+              "status": {
+                "type": "IN_PROGRESS",
+                "name": "In Progress"
+              },
+              "progress": {
+                "completed_count": 4,
+                "total_count": 11,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1992?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Garothi Worldbreaker",
+                      "id": 1992
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602393421000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1987?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Felhounds of Sargeras",
+                      "id": 1987
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602394504000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1997?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Antoran High Command",
+                      "id": 1997
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602395817000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/1985?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Portal Keeper Hasabel",
+                      "id": 1985
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1602396810000
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "expansion": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/journal-expansion/396?namespace=static-9.1.0_39069-us"
+        },
+        "name": "Battle for Azeroth",
+        "id": 396
+      },
+      "instances": [
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/1031?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Uldir",
+            "id": 1031
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "LFR",
+                "name": "Raid Finder"
+              },
+              "status": {
+                "type": "IN_PROGRESS",
+                "name": "In Progress"
+              },
+              "progress": {
+                "completed_count": 3,
+                "total_count": 8,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2168?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Taloc",
+                      "id": 2168
+                    },
+                    "completed_count": 2,
+                    "last_kill_timestamp": 1537753125000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2167?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "MOTHER",
+                      "id": 2167
+                    },
+                    "completed_count": 2,
+                    "last_kill_timestamp": 1537753582000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2169?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Zek'voz, Herald of N'Zoth",
+                      "id": 2169
+                    },
+                    "completed_count": 2,
+                    "last_kill_timestamp": 1537754299000
+                  }
+                ]
+              }
+            },
+            {
+              "difficulty": {
+                "type": "NORMAL",
+                "name": "Normal"
+              },
+              "status": {
+                "type": "IN_PROGRESS",
+                "name": "In Progress"
+              },
+              "progress": {
+                "completed_count": 6,
+                "total_count": 8,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2168?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Taloc",
+                      "id": 2168
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1537319576000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2167?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "MOTHER",
+                      "id": 2167
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1537319997000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2146?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Fetid Devourer",
+                      "id": 2146
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1537320807000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2169?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Zek'voz, Herald of N'Zoth",
+                      "id": 2169
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1537323092000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2166?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Vectis",
+                      "id": 2166
+                    },
+                    "completed_count": 2,
+                    "last_kill_timestamp": 1537321974000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2195?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Zul, Reborn",
+                      "id": 2195
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1536719761000
+                  }
+                ]
+              }
+            },
+            {
+              "difficulty": {
+                "type": "HEROIC",
+                "name": "Heroic"
+              },
+              "status": {
+                "type": "IN_PROGRESS",
+                "name": "In Progress"
+              },
+              "progress": {
+                "completed_count": 2,
+                "total_count": 8,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2168?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Taloc",
+                      "id": 2168
+                    },
+                    "completed_count": 2,
+                    "last_kill_timestamp": 1537317210000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2167?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "MOTHER",
+                      "id": 2167
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1536803756000
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "expansion": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/journal-expansion/499?namespace=static-9.1.0_39069-us"
+        },
+        "name": "Shadowlands",
+        "id": 499
+      },
+      "instances": [
+        {
+          "instance": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/journal-instance/1190?namespace=static-9.1.0_39069-us"
+            },
+            "name": "Castle Nathria",
+            "id": 1190
+          },
+          "modes": [
+            {
+              "difficulty": {
+                "type": "NORMAL",
+                "name": "Normal"
+              },
+              "status": {
+                "type": "COMPLETE",
+                "name": "Complete"
+              },
+              "progress": {
+                "completed_count": 10,
+                "total_count": 10,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2393?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Shriekwing",
+                      "id": 2393
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1609986092000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2429?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Huntsman Altimor",
+                      "id": 2429
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1609986929000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2422?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Sun King's Salvation",
+                      "id": 2422
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1609989796000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2418?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Artificer Xy'mox",
+                      "id": 2418
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1609990725000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2428?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Hungering Destroyer",
+                      "id": 2428
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1609987579000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2420?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Lady Inerva Darkvein",
+                      "id": 2420
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1609988176000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2426?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "The Council of Blood",
+                      "id": 2426
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1611988800000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2394?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Sludgefist",
+                      "id": 2394
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1611991731000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2425?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Stone Legion Generals",
+                      "id": 2425
+                    },
+                    "completed_count": 4,
+                    "last_kill_timestamp": 1611992650000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2424?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Sire Denathrius",
+                      "id": 2424
+                    },
+                    "completed_count": 2,
+                    "last_kill_timestamp": 1610077219000
+                  }
+                ]
+              }
+            },
+            {
+              "difficulty": {
+                "type": "HEROIC",
+                "name": "Heroic"
+              },
+              "status": {
+                "type": "IN_PROGRESS",
+                "name": "In Progress"
+              },
+              "progress": {
+                "completed_count": 4,
+                "total_count": 10,
+                "encounters": [
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2393?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Shriekwing",
+                      "id": 2393
+                    },
+                    "completed_count": 5,
+                    "last_kill_timestamp": 1612405678000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2429?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Huntsman Altimor",
+                      "id": 2429
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1611802731000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2418?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Artificer Xy'mox",
+                      "id": 2418
+                    },
+                    "completed_count": 1,
+                    "last_kill_timestamp": 1611202232000
+                  },
+                  {
+                    "encounter": {
+                      "key": {
+                        "href": "https://us.api.blizzard.com/data/wow/journal-encounter/2428?namespace=static-9.1.0_39069-us"
+                      },
+                      "name": "Hungering Destroyer",
+                      "id": 2428
+                    },
+                    "completed_count": 3,
+                    "last_kill_timestamp": 1611803957000
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/frontend/src/store/defaults.js
+++ b/frontend/src/store/defaults.js
@@ -89,4 +89,26 @@ export const defaultPets = {
 	]
 };
 
-export const defaultStore = { characters: defaultChar, gear: defaultGear, mounts: defaultMounts, pets: defaultPets };
+export const expansionTemplate = {
+	"Classic": {},
+	"Burning Crusade": {},
+	"Wrath of the Lich King": {},
+	"Cataclysm": {},
+	"Mists of Pandaria": {},
+	"Warlords of Draenor": {},
+	"Legion": {},
+	"Battle for Azeroth": {},
+	"Shadowlands": {}
+}
+
+export const defaultRaids = {
+	bryce_morgan: {...expansionTemplate}
+}
+
+export const defaultStore = { 
+	characters: defaultChar, 
+	gear: defaultGear, 
+	mounts: defaultMounts, 
+	pets: defaultPets ,
+	raids: defaultRaids
+};

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -4,6 +4,7 @@ import { petReducer } from './pets';
 import { characterReducer } from './characters';
 import { gearReducer } from './gear';
 import { mountReducer } from './mounts';
+import { raidReducer } from './raids';
 
 import { sessionReducer } from './session';
 
@@ -12,7 +13,8 @@ const rootReducer = combineReducers({
 	characters: characterReducer,
 	gear: gearReducer,
 	mounts: mountReducer,
-	pets: petReducer
+	pets: petReducer,
+	raids: raidReducer
 });
 
 let enhancer;

--- a/frontend/src/store/mounts.js
+++ b/frontend/src/store/mounts.js
@@ -50,14 +50,13 @@ export const fetchMountData = (id, oAuth) => async (dispatch) => {
 	const mountData = await fetchRetry(
 		`https://us.api.blizzard.com/data/wow/mount/${id}?namespace=static-us&locale=en_US&access_token=${oAuth}`
 	);
-	// const mountData = await mountRes.json();
 
 	const mediaData = await fetchRetry(
 		`https://us.api.blizzard.com/data/wow/media/creature-display/${mountData.creature_displays[0]
 			.id}?namespace=static-us&locale=en_US&access_token=${oAuth}`
 	);
-	// const mediaData = await mediaRes.json();
-	const selectedData = await selectMountDetails(mountData, mediaData);
+	
+	const selectedData = selectMountDetails(mountData, mediaData);
 
 	dispatch(receiveMountDetails(selectedData));
 };

--- a/frontend/src/store/pets.js
+++ b/frontend/src/store/pets.js
@@ -44,7 +44,7 @@ export const fetchPetData = (id, creatureDisplayId, oAuth) => async (dispatch) =
 				`https://us.api.blizzard.com/data/wow/media/creature-display/${creatureDisplayId}?namespace=static-us&locale=en_US&access_token=${oAuth}`
 			)
 		: null;
-	const selectedData = await selectPetDetails(petData, mediaData);
+	const selectedData = selectPetDetails(petData, mediaData);
 
 	dispatch(receivePetDetails(selectedData));
 };

--- a/frontend/src/store/raids.js
+++ b/frontend/src/store/raids.js
@@ -39,13 +39,11 @@ export const fetchRaidData = (id, oAuth) => async (dispatch) => {
 	const raidData = await fetchRetry(
 		`https://us.api.blizzard.com/data/wow/journal-instance/${id}?namespace=static-us&locale=en_US&access_token=${oAuth}`
 	);
-	// const mountData = await mountRes.json();
 
 	const mediaData = await fetchRetry(
 		`https://us.api.blizzard.com/data/wow/media/journal-instance/${id}?namespace=static-us&locale=en_US&access_token=${oAuth}`
 	);
-	// const mediaData = await mediaRes.json();
-	const selectedData = await selectRaidDetails(raidData, mediaData);
+	const selectedData = selectRaidDetails(raidData, mediaData);
 
 	dispatch(receiveRaidDetails(selectedData));
 };

--- a/frontend/src/store/raids.js
+++ b/frontend/src/store/raids.js
@@ -1,0 +1,35 @@
+import { selectCharRaidData } from './selectors';
+
+export const RECEIVE_CHAR_RAIDS = 'RECEIVE_CHAR_RAIDS';
+
+export const receiveRaids = (key, data) => {
+	return {
+		type: RECEIVE_CHAR_RAIDS,
+		key,
+		data
+	};
+};
+
+// Fetches raid progression data from Blizzard API
+export const fetchRaids = (region, realm, name, oAuth) => async (dispatch) => {
+	const raidRes = await fetch(
+		`https://${region}.api.blizzard.com/profile/wow/character/${realm}/${name}/encounters/raids?namespace=profile-${region}&locale=en_US&access_token=${oAuth}`
+	);
+	const raidData = await raidRes.json();
+	const selectedData = selectCharRaidData(raidData);
+
+	// A unique character key is generated combining the region, realm, and name
+	// This is used in multiple slices of the Redux store to retrieve cached data
+	const charKey = `${region}_${realm}_${name}`;
+	dispatch(receiveRaids(charKey, selectedData));
+	return selectedData;
+};
+
+export const raidReducer = (state = {}, action) => {
+	switch (action.type) {
+		case RECEIVE_CHAR_RAIDS:
+			return { ...state, [action.key]: action.data };
+		default:
+			return state;
+	}
+};

--- a/frontend/src/store/raids.js
+++ b/frontend/src/store/raids.js
@@ -1,11 +1,20 @@
-import { selectCharRaidData } from './selectors';
+import { selectCharRaidData, selectRaidDetails } from './selectors';
+import { fetchRetry } from '../utility.js';
 
 export const RECEIVE_CHAR_RAIDS = 'RECEIVE_CHAR_RAIDS';
+export const RECEIVE_RAID_DETAILS = 'RECEIVE_RAID_DETAILS';
 
 export const receiveRaids = (key, data) => {
 	return {
 		type: RECEIVE_CHAR_RAIDS,
 		key,
+		data
+	};
+};
+
+export const receiveRaidDetails = (data) => {
+	return {
+		type: RECEIVE_RAID_DETAILS,
 		data
 	};
 };
@@ -25,10 +34,28 @@ export const fetchRaids = (region, realm, name, oAuth) => async (dispatch) => {
 	return selectedData;
 };
 
+// Fetches data about a specific raid (media, name, area, description, etc.) from Blizzard API
+export const fetchRaidData = (id, oAuth) => async (dispatch) => {
+	const raidData = await fetchRetry(
+		`https://us.api.blizzard.com/data/wow/journal-instance/${id}?namespace=static-us&locale=en_US&access_token=${oAuth}`
+	);
+	// const mountData = await mountRes.json();
+
+	const mediaData = await fetchRetry(
+		`https://us.api.blizzard.com/data/wow/media/journal-instance/${id}?namespace=static-us&locale=en_US&access_token=${oAuth}`
+	);
+	// const mediaData = await mediaRes.json();
+	const selectedData = await selectRaidDetails(raidData, mediaData);
+
+	dispatch(receiveRaidDetails(selectedData));
+};
+
 export const raidReducer = (state = {}, action) => {
 	switch (action.type) {
 		case RECEIVE_CHAR_RAIDS:
 			return { ...state, [action.key]: action.data };
+		case RECEIVE_RAID_DETAILS:
+			return { ...state, [action.data.id]: action.data };
 		default:
 			return state;
 	}

--- a/frontend/src/store/selectors.js
+++ b/frontend/src/store/selectors.js
@@ -156,7 +156,6 @@ export function selectCharRaidData(body) {
 			instances : {}
 		};
 		
-
 		expansion.instances.forEach((instance) => {
 			const instanceData = {
 				name: instance.instance.name,
@@ -183,4 +182,20 @@ export function selectCharRaidData(body) {
 		raidData[expansion.expansion.name] =  expansionData;
 	});
 	return raidData;
+};
+
+//  Strips, reformats, and combines mount details and media to relevent data
+export async function selectRaidDetails(raidData, mediaData) {
+	return {
+		id: raidData.id,
+		name: raidData.name,
+		description: raidData.description,
+		location: raidData.location.name,
+		locationId: raidData.location.id,
+		minLvl: raidData.minimum_level,
+		media: {
+			id: raidData.media.id,
+			href: mediaData.assets[0].value
+		}
+	};
 };

--- a/frontend/src/store/selectors.js
+++ b/frontend/src/store/selectors.js
@@ -66,7 +66,7 @@ export function selectCharMountData(body) {
 };
 
 //  Strips, reformats, and combines mount details and media to relevent data
-export async function selectMountDetails(mountData, mediaData) {
+export function selectMountDetails(mountData, mediaData) {
 	return {
 		id: mountData.id,
 		name: mountData.name,
@@ -97,7 +97,7 @@ export function selectCharPetData(body) {
 // A defaultPet is created due to some requests for character pets results in 404s
 // from Blizzard API. If that data doesn't exist we still want to have the keys
 // present in our returned object.
-export async function selectPetDetails(petData, mediaData) {
+export function selectPetDetails(petData, mediaData) {
 	let selected = { ...defaultPet };
 	if (petData) {
 		selected = {
@@ -184,18 +184,24 @@ export function selectCharRaidData(body) {
 	return raidData;
 };
 
-//  Strips, reformats, and combines mount details and media to relevent data
-export async function selectRaidDetails(raidData, mediaData) {
+//  Strips, reformats, and combines raid details and media to relevent data
+export function selectRaidDetails(raidData, mediaData) {
 	return {
 		id: raidData.id,
 		name: raidData.name,
 		description: raidData.description,
-		location: raidData.location.name,
-		locationId: raidData.location.id,
-		minLvl: raidData.minimum_level,
+		wowheadTitle: formatWowheadRaidTitle(raidData.name),
 		media: {
 			id: raidData.media.id,
 			href: mediaData.assets[0].value
 		}
 	};
 };
+
+function formatWowheadRaidTitle(raidName) {
+	// The Battle for Mount Hyjal is an exception for the Wowhead naming convention
+	// Return the correct article title immediately for it, otherwise convert with 
+	// standard process, stripping ' and , and replacing spaces with -
+	return raidName === 'The Battle for Mount Hyjal' ? 'hyjal-summit' :
+	raidName.toLowerCase().replaceAll(' ', '-').replaceAll(/'|,/g, '')
+}

--- a/frontend/src/store/selectors.js
+++ b/frontend/src/store/selectors.js
@@ -1,3 +1,5 @@
+import { expansionTemplate } from "./defaults";
+
 // Strips the large character and media objects down to data that will be used by the app
 export function selectCharInfo(region, charData, media) {
 	const assets = {};
@@ -22,7 +24,7 @@ export function selectCharInfo(region, charData, media) {
 		lastLogin: new Date(charData.last_login_timestamp).toLocaleString(),
 		assets
 	};
-}
+};
 
 // Returns an array of simplified character data for each item in charHistory
 // The simplified data is used to make history buttons in CharacterHistory component
@@ -38,7 +40,7 @@ export function selectIndexData(state) {
 			class: iteratingChar.class
 		};
 	});
-}
+};
 
 // Strips the large object of gear data to only that which will be used by the app
 export function selectGearData(body) {
@@ -52,7 +54,7 @@ export function selectGearData(body) {
 		};
 	});
 	return gearData;
-}
+};
 
 // Strips the large object of mount data to only that which will be used by the app
 export function selectCharMountData(body) {
@@ -61,7 +63,7 @@ export function selectCharMountData(body) {
 		name: mount.name,
 		is_useable
 	}));
-}
+};
 
 //  Strips, reformats, and combines mount details and media to relevent data
 export async function selectMountDetails(mountData, mediaData) {
@@ -75,7 +77,7 @@ export async function selectMountDetails(mountData, mediaData) {
 			href: mediaData.assets[0].value
 		}
 	};
-}
+};
 
 // Strips the large object of pet data to only that which will be used by the app
 export function selectCharPetData(body) {
@@ -89,7 +91,7 @@ export function selectCharPetData(body) {
 		quality: pet.quality.name,
 		isFavorite: pet.is_favorite
 	}));
-}
+};
 
 // Strips, reformats, and combines pet details and media to relevent data
 // A defaultPet is created due to some requests for character pets results in 404s
@@ -118,7 +120,7 @@ export async function selectPetDetails(petData, mediaData) {
 	}
 
 	return selected;
-}
+};
 
 const defaultPet = {
 	id: null,
@@ -143,4 +145,42 @@ export function selectAvailableRealms(realmData) {
 	availableRealms.push({ name: '--Select Realm--', slug: '' });
 	// Sort realms alphabetically by name instead of the default id
 	return availableRealms.sort((a, b) => (a.name < b.name ? -1 : 1));
-}
+};
+
+export function selectCharRaidData(body) {
+	const raidData = {...expansionTemplate};
+	body.expansions.forEach((expansion) => {
+		const expansionData = {
+			name : expansion.expansion.name,
+			id: expansion.expansion.id,
+			instances : {}
+		};
+		
+
+		expansion.instances.forEach((instance) => {
+			const instanceData = {
+				name: instance.instance.name,
+				id: instance.instance.id,
+				modes: {}
+			}
+
+			instance.modes.forEach((mode) => {
+				const modeData = {
+					name: mode.difficulty.name,
+					status: mode.status.name,
+					progress: {
+						completed: mode.progress.completed_count,
+						total: mode.progress.total_count
+					}
+				};
+
+				instanceData.modes[mode.difficulty.name] = modeData;
+			})
+
+			expansionData.instances[instance.instance.name] = instanceData;
+		})
+
+		raidData[expansion.expansion.name] =  expansionData;
+	});
+	return raidData;
+};

--- a/frontend/src/store/selectors.js
+++ b/frontend/src/store/selectors.js
@@ -149,6 +149,13 @@ export function selectAvailableRealms(realmData) {
 
 export function selectCharRaidData(body) {
 	const raidData = {...expansionTemplate};
+	
+	// If a character has no raid data, Blizzard API still returns a successful 
+	// response of an object with basic character data instead of raid data.
+	// If this occurs, return the empty raidData object we created before trying 
+	// to unpack the non-existent raid data from the response.
+	if (!body.expansions) return raidData;
+
 	body.expansions.forEach((expansion) => {
 		const expansionData = {
 			name : expansion.expansion.name,
@@ -166,7 +173,7 @@ export function selectCharRaidData(body) {
 			instance.modes.forEach((mode) => {
 				const modeData = {
 					name: mode.difficulty.name,
-					status: mode.status.name,
+					status: mode.status.type,
 					progress: {
 						completed: mode.progress.completed_count,
 						total: mode.progress.total_count

--- a/frontend/src/styles/CharacterRaids.scss
+++ b/frontend/src/styles/CharacterRaids.scss
@@ -1,0 +1,25 @@
+@import './variables.scss';
+
+.raid-details {
+	width: 70%;
+	min-width: 300px;
+	padding: 5px;
+	background-color: $midbackground;
+	max-height: 60%;
+	margin: 10px 10px 0px 5px;
+	color: white;
+	border-radius: 2px;
+
+	header {
+		text-align: center;
+		font-size: 20px;
+		border-bottom: 1px solid black;
+		margin-bottom: 5px;
+	}
+
+  ul {
+    max-height: calc(100% - 30px);
+		overflow-y: auto;
+		@include scrollbars;
+	}
+}

--- a/frontend/src/styles/DetailIndexItem.scss
+++ b/frontend/src/styles/DetailIndexItem.scss
@@ -30,6 +30,13 @@
 			&.mount {
 				width: 30%;
 			}
+			&.raid {
+				width: 100px;
+				height: 100px;
+				object-fit: fill;
+				border-radius: 50%;
+				border: 3px solid $darkbackground;
+			}
 		}
 
 		.index-name,
@@ -39,7 +46,12 @@
 			cursor: pointer;
 			font-size: 16px;
 		}
+
+		&.raid{
+			flex-direction: column;
+		}
 	}
+
 
 	&::before {
 		position: absolute;

--- a/frontend/src/styles/RaidInstanceIndexItem.scss
+++ b/frontend/src/styles/RaidInstanceIndexItem.scss
@@ -1,0 +1,35 @@
+@import './variables.scss';
+
+.expansion-instance-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  .instance-container {
+    margin: 10px 5px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+.IN_PROGRESS {
+  color: yellow;
+}
+
+.COMPLETE {
+  color: green;
+}
+
+.title-container {
+  width: calc(100% - 10px);
+  display: flex;
+  cursor: pointer;
+}
+
+.open {
+  .title-container{
+    border-bottom: 2px solid $darkbackground;
+    margin-bottom: 5px;
+  }
+}


### PR DESCRIPTION
Adds raid progression details for characters
  - Raid section added alongside the gear/pet/mount components
  - Raids are broken down by expansion, with drop-down component for each
  - Official raid images fetched from Blizzard Game Data API when a raid is present
  - Raids and modes/difficulties are only displayed when progression exists for it with the displayed character
  - Font distinguishes completed/in progress raids (green/yellow color)
  - Links are generated to the appropriate Wowhead article for each raid

General changes:
  - Removes several unnecessary `async` declarations for functions
  - Changes links to open in new tabs with `target='_blank'`